### PR TITLE
Fixed senderId to senderID

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const useRequestNotifications = (
       onError: error => setError(error),
       onNotification: notification => notifications.map(f => f(notification)),
       permissions: { alert, badge, sound },
-      senderId: application_id
+      senderID: application_id
     });
     tokens.push(setToken);
     if (deviceToken) setToken(deviceToken);


### PR DESCRIPTION
This fixes a bug in android where device token is never requested.

This was not a bug in iOS because iOS does not use the senderID field